### PR TITLE
Changing duplicate borough codes to prevent crashes when submitting variations

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,8 +1,8 @@
 -- TEAMS
 INSERT INTO team(id, team_code, team_description, team_telephone, borough_code, borough_description, district_code, district_description) VALUES
 (1, 'cvl', 'Licence Team', '0800001066', 'N55PDU', 'Nottingham', 'N55LAU', 'Nottingham South'),
-(2, 'cvl2', 'Alpha Team', '0800001066', 'N55PDU', 'Nottingham', 'N55LAU', 'Nottingham South'),
-(3, 'cvl3', 'Beta Team', '0800001066', 'N55PDU', 'Nottingham', 'N55LAU', 'Nottingham South');
+(2, 'cvl2', 'Alpha Team', '0800001066', 'N55PDV', 'Nottingham 2', 'N55LAU', 'Nottingham South'),
+(3, 'cvl3', 'Beta Team', '0800001066', 'N55PDW', 'Nottingham 3', 'N55LAU', 'Nottingham South');
 
 -- STAFF
 -- Only put your email address here if you want to receive notifications via Gov UK Notify


### PR DESCRIPTION
It appears that having duplicate borough codes was causing a crash when calling the PduHead endpoint. 
I'm not currently sure whether this is something that is always unique per-team in Delius, or if this is an issue that's arising from using mocked data.
If issues with cases not appearing in the correct views begin to occur, this PR should be rolled-back and investigated further.