### PR TITLE
CVSL-999 add missing sortBy parameters

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/dto/request/ProbationSearchRequest.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/dto/request/ProbationSearchRequest.java
@@ -8,5 +8,5 @@ import java.util.List;
 public class ProbationSearchRequest {
     List<String> teamCodes;
     String query;
-    ProbationSearchSortByRequest sortBy;
+    List<ProbationSearchSortByRequest> sortBy;
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/resource/DeliusResource.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/resource/DeliusResource.java
@@ -182,7 +182,9 @@ public class DeliusResource {
 
   @PostMapping(value = "/licence-caseload/by-team")
   public ProbationSearchResponse getProbationSearchResult(@RequestBody ProbationSearchRequest body) {
-    List<ProbationSearchContent> content =  service.getProbationSearchResult(body.getTeamCodes(), body.getQuery(), body.getSortBy().get(0)).stream()
+    List<ProbationSearchContent> content = service
+            .getProbationSearchResult(body.getTeamCodes(), body.getQuery(), body.getSortBy().get(0))
+            .stream()
             .map(mapper::fromEntityToProbationSearchContent)
             .toList();
     ProbationSearchResponse response = new ProbationSearchResponse();

--- a/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/resource/DeliusResource.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/resource/DeliusResource.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.dao.entity.OffenderEntity;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.dao.entity.StaffEntity;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.dto.request.ProbationSearchRequest;
+import uk.gov.justice.digital.hmpps.communityApiWiremock.dto.request.ProbationSearchSortByRequest;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.dto.request.SearchProbationerRequest;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.dto.response.CaseloadResponse;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.dto.response.CommunityOrPrisonOffenderManager;
@@ -181,7 +182,8 @@ public class DeliusResource {
 
   @PostMapping(value = "/licence-caseload/by-team")
   public ProbationSearchResponse getProbationSearchResult(@RequestBody ProbationSearchRequest body) {
-    List<ProbationSearchContent> content =  service.getProbationSearchResult(body.getTeamCodes(), body.getQuery()).stream()
+    ProbationSearchSortByRequest sortBy = body.getSortBy().get(0);
+    List<ProbationSearchContent> content =  service.getProbationSearchResult(body.getTeamCodes(), body.getQuery(), sortBy).stream()
             .map(mapper::fromEntityToProbationSearchContent)
             .toList();
     ProbationSearchResponse response = new ProbationSearchResponse();

--- a/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/resource/DeliusResource.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/resource/DeliusResource.java
@@ -182,8 +182,7 @@ public class DeliusResource {
 
   @PostMapping(value = "/licence-caseload/by-team")
   public ProbationSearchResponse getProbationSearchResult(@RequestBody ProbationSearchRequest body) {
-    ProbationSearchSortByRequest sortBy = body.getSortBy().get(0);
-    List<ProbationSearchContent> content =  service.getProbationSearchResult(body.getTeamCodes(), body.getQuery(), sortBy).stream()
+    List<ProbationSearchContent> content =  service.getProbationSearchResult(body.getTeamCodes(), body.getQuery(), body.getSortBy().get(0)).stream()
             .map(mapper::fromEntityToProbationSearchContent)
             .toList();
     ProbationSearchResponse response = new ProbationSearchResponse();

--- a/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/service/DeliusService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/service/DeliusService.java
@@ -87,6 +87,7 @@ public class DeliusService {
 
   public List<OffenderEntity> getProbationSearchResult(List<String> teamCodes, String query, ProbationSearchSortByRequest sortBy) {
     String searchString = query.toLowerCase().trim();
+
     if (searchString.isEmpty())
       return List.of();
 

--- a/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/service/DeliusService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/communityApiWiremock/service/DeliusService.java
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.communityApiWiremock.dao.entity.TeamEntity;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.dao.repository.OffenderRepository;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.dao.repository.StaffRepository;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.dao.repository.TeamRepository;
+import uk.gov.justice.digital.hmpps.communityApiWiremock.dto.request.ProbationSearchSortByRequest;
 import uk.gov.justice.digital.hmpps.communityApiWiremock.exception.NotFoundException;
 
 @Service
@@ -84,16 +85,27 @@ public class DeliusService {
     return this.offenderRepository.findByNomsNumberIn(nomsNumbers);
   }
 
-  public List<OffenderEntity> getProbationSearchResult(List<String> teamCodes, String query) {
+  public List<OffenderEntity> getProbationSearchResult(List<String> teamCodes, String query, ProbationSearchSortByRequest sortBy) {
     String searchString = query.toLowerCase().trim();
-
     if (searchString.isEmpty())
       return List.of();
+
+    Comparator<OffenderEntity> sortPreference;
+
+    if (sortBy.getField() == "name.forename") {
+      if (sortBy.getDirection() == "asc") {
+        sortPreference = Comparator.comparing(OffenderEntity::getForename);
+      } else {
+        sortPreference = Comparator.comparing(OffenderEntity::getForename, Comparator.reverseOrder());
+      }
+    } else {
+      sortPreference = Comparator.comparing(OffenderEntity::getSurname);
+    }
 
     return teamCodes.stream()
             .flatMap(teamCode -> getAllOffendersByTeamCode(teamCode).stream())
             .filter(offender -> matchesOffender(offender, searchString))
-            .sorted(Comparator.comparing(OffenderEntity::getForename))
+            .sorted(sortPreference)
             .toList();
   }
 


### PR DESCRIPTION
This PR adds the missing sortBy parameter for the mocked /licence-caseload/by-team endpoint as well as changing the composition of the search request as it was missing the changes made in the API. 