### PR TITLE
update to latest image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,5 @@
 version: 2.1
 
-commands:
-  install-docker-buildx:
-    steps:
-      - run:
-          name: Install Docker BuildX
-          command: |
-            mkdir -vp ~/.docker/cli-plugins/
-            curl --silent -L "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx version
-            sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-            docker run --privileged --rm tonistiigi/binfmt --install arm64
-            docker context create buildcontext
-            docker buildx create buildcontext --use
-
-  configure-quayio-credentials:
-    steps:
-      - run:
-          name: Configure Quay.io credentials
-          command: |
-            docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io
-
 jobs:
   validate:
     docker:
@@ -36,12 +13,25 @@ jobs:
           name: Run tests
           command: mvn test
   push:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      image: cimg/base:stable
     steps:
       - checkout
-      - install-docker-buildx
-      - configure-quayio-credentials
+      - run:
+          name: Install Docker BuildX for Multi-architecture builds
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx version
+            sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker run --privileged --rm tonistiigi/binfmt --install arm64
+            docker context create buildcontext
+            docker buildx create buildcontext --use
+      - run:
+          name: Quay.io Login
+          command: docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io
       - run:
           name: Tag and Push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,3 @@ workflows:
       - push:
           requires:
             - validate
-          filters:
-            branches:
-              only:
-                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: mvn test
   push:
     machine:
-      image: ubuntu-2004:202010-01
+      image: cimg/base:2025.01
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Install Docker BuildX for Multi-architecture builds
           command: |
             mkdir -vp ~/.docker/cli-plugins/
-            curl --silent -L "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+            curl --silent -L "https://github.com/docker/buildx/releases/download/v0.19.3/buildx-v0.19.3.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
             chmod a+x ~/.docker/cli-plugins/docker-buildx
             docker buildx version
             sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,7 @@ jobs:
           command: mvn test
   push:
     machine:
-      image: ubuntu-2204:current
-    resource_class: 2xlarge
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: mvn test
   push:
     machine:
-      image: cimg/base:stable
+      image: cimg/base:2025.01
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: mvn test
   push:
     docker:
-      image: cimg/base:stable
+      - image: cimg/base:stable
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
           name: Run tests
           command: mvn test
   push:
-    machine:
-      image: cimg/base:2025.01
+    docker:
+      - image: cimg/base:2025.01
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,9 @@ jobs:
           name: Run tests
           command: mvn test
   push:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      image: cimg/base:stable
+    resource_class: 2xlarge
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,3 +50,7 @@ workflows:
       - push:
           requires:
             - validate
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
           name: Run tests
           command: mvn test
   push:
-    machine:
-      image: cimg/base:2025.01
+    docker:
+      image: cimg/base:stable
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,28 @@
 version: 2.1
 
+commands:
+  install-docker-buildx:
+    steps:
+      - run:
+          name: Install Docker BuildX
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx version
+            sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker run --privileged --rm tonistiigi/binfmt --install arm64
+            docker context create buildcontext
+            docker buildx create buildcontext --use
+
+  configure-quayio-credentials:
+    steps:
+      - run:
+          name: Configure Quay.io credentials
+          command: |
+            docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io
+
 jobs:
   validate:
     docker:
@@ -14,24 +37,11 @@ jobs:
           command: mvn test
   push:
     docker:
-      - image: cimg/base:2025.01
+      - image: cimg/base:stable
     steps:
       - checkout
-      - run:
-          name: Install Docker BuildX for Multi-architecture builds
-          command: |
-            mkdir -vp ~/.docker/cli-plugins/
-            curl --silent -L "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx version
-            sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-            docker run --privileged --rm tonistiigi/binfmt --install arm64
-            docker context create buildcontext
-            docker buildx create buildcontext --use
-      - run:
-          name: Quay.io Login
-          command: docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io
+      - install-docker-buildx
+      - configure-quayio-credentials
       - run:
           name: Tag and Push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: mvn test
   push:
     machine:
-      image: cimg/base:stable
+      image: ubuntu-2204:current
     resource_class: 2xlarge
     steps:
       - checkout


### PR DESCRIPTION
This PR is to update the image to use the latest ubuntu one. Tried using the cimg image but it wouldn't run the command to install buildx for Docker - checked on Github and some others had used :current. Changed it to this and updated the github link from where buildx is downloaded from to be the latest one and seems all ok. 